### PR TITLE
Update BBVA name (now GNB Fusión) and URL

### DIFF
--- a/coti.py
+++ b/coti.py
@@ -306,7 +306,7 @@ def lamoneda():
 def bbva():
     try:
         soup = requests.get(
-            "https://www.bbva.com.py/Yaguarete/public/quotations", timeout=10
+            "https://www.bancognbcaminamosjuntos.com.py/Yaguarete/public/quotations", timeout=10
         ).json()
         compra = soup[0]["cashBuyPrice"]
         venta = soup[0]["cashSellPrice"]
@@ -373,7 +373,7 @@ def create_json():
             #     'compra': famicompra,
             #     'venta': famiventa
             # }
-            "bbva": {"compra": bbvacompra, "venta": bbvaventa},
+            "gnbfusion": {"compra": bbvacompra, "venta": bbvaventa},
             "mundialcambios": {"compra": wcompra, "venta": wventa},
             'vision': {
                 'compra': visioncompra,

--- a/templates/index.html
+++ b/templates/index.html
@@ -280,7 +280,7 @@
             </div>
             <div class="mdl-card__actions mdl-card--border">
                 <a class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
-                    BBVA
+                    GNB Fusión (Ex BBVA)
                 </a>
             </div>
         </div>
@@ -471,8 +471,8 @@ var vlamoneda;
                     ambventa = json.dolarpy.amambay.venta;
                     mydcompra = json.dolarpy.mydcambios.compra;
                     mydventa = json.dolarpy.mydcambios.venta;
-                    bbvacompra = json.dolarpy.bbva.compra;
-                    bbvaventa = json.dolarpy.bbva.venta;
+                    bbvacompra = json.dolarpy.gnbfusion.compra;
+                    bbvaventa = json.dolarpy.gnbfusion.venta;
                     eccompra = json.dolarpy.eurocambios.compra;
                     ecventa = json.dolarpy.eurocambios.venta;
                     wcompra = json.dolarpy.mundialcambios.compra;


### PR DESCRIPTION
No todas las ocurrencias de _bbva_ fueron reemplazadas (al menos por ahora) para evitar modificaciones extra en el código.